### PR TITLE
Fix compatibility with Mediainfo Improvements userscript

### DIFF
--- a/sk/static/animebytesmark.user.js
+++ b/sk/static/animebytesmark.user.js
@@ -3,13 +3,14 @@
 // @description Tags the best releases on AnimeBytes according to https://releases.moe/
 // @namespace   ThaUnknown
 // @match       *://animebytes.tv/*
-// @version     1.0.1
+// @version     1.0.2
 // @author      ThaUnknown
 // @grant       GM_xmlhttpRequest
 // @icon        http://animebytes.tv/favicon.ico
 // @downloadURL https://releases.moe/animebytesmark.user.js
 // @connect     releases.moe
 // @license     MIT
+// @run-at      document-idle
 // ==/UserScript==
 
 /* global $ */
@@ -69,21 +70,21 @@ async function fetchSeadex (ids) {
 }
 
 // Thanks to https://github.com/momentary0/AB-Userscripts/blob/master/torrent-highlighter/src/tfm_torrent_highlighter.user.js#L470
-// for the handy selectors
+// for the handy selectors, slightly modified here to work together with the Mediainfo Improvements userscript
 function torrentsOnPage () {
   const torrentPageTorrents = [...document.querySelectorAll(
-    (window.location.href.includes('torrents.php') ? '' : '#anime_table ') + '.group_torrent>td>a[href*="&torrentid="]'
+    (window.location.href.includes('torrents.php') ? '' : '#anime_table ') + '.group_torrent>td:not(:has(+ td>a[href*="&torrentid="]))>a[href*="&torrentid="]'
   )].map(a => ({
     a,
     torrentId: a.href.match(TORRENT_ID_REGEX)[1],
-    seperator: a.href.includes('torrents.php') ? ' | ' : ' / '
+    separator: a.href.includes('torrents.php') && a.text.includes('|') ? ' | ' : ' / '
   }))
   const searchResultTorrents = [...document.querySelectorAll(
     '.torrent_properties>a[href*="&torrentid="]'
   )].map(a => ({
     a,
     torrentId: a.href.match(TORRENT_ID_REGEX)[1],
-    seperator: ' | '
+    separator: ' | '
   }))
   return [...torrentPageTorrents, ...searchResultTorrents]
 }
@@ -116,7 +117,7 @@ function insertTorrentTab (torrentId, tabName, tabId, content) {
       if (!entry) continue
 
       // Insert tag
-      torrentLink.a.append(torrentLink.seperator)
+      torrentLink.a.append(torrentLink.separator)
       let parent = torrentLink.a
       if (torrentLink.a.classList.contains('userscript-highlight')) {
         // highlight already ran


### PR DESCRIPTION
The Mediainfo Improvements userscript splits the torrent table cell into multiple cells, which means the SeaDex tag image and tab get duplicated.

I changed the torrent selector to only match every cell where the cell directly following it does not have a matching link tag, which in our case means it'll select the last cell that still contains a link. Best thing I could come up with using only a single `querySelectorAll` call that works both with and without the Mediainfo Improvements script.

Before
![image](https://github.com/user-attachments/assets/cc4e5d5e-ada1-4fb2-b893-08556cce6643)
After
![image](https://github.com/user-attachments/assets/f56ae207-d7d5-4f03-949b-80b7156a10df)

---

The tag image also wouldn't show up if this script was loaded before the Mediainfo Improvements one, as by the time we try to modify the cells they no longer exist after having been removed by the Mediainfo Improvements script. So I changed it to scan the page again if the stored elements don't exist on the page anymore (only checking the first one should probably suffice).