### PR TITLE
fix: update AB marker script for a consistent look and change load order

### DIFF
--- a/sk/static/animebytesmark.user.js
+++ b/sk/static/animebytesmark.user.js
@@ -3,13 +3,14 @@
 // @description Tags the best releases on AnimeBytes according to https://releases.moe/
 // @namespace   ThaUnknown
 // @match       *://animebytes.tv/*
-// @version     1.0.2
+// @version     1.0.3
 // @author      ThaUnknown
 // @grant       GM_xmlhttpRequest
 // @icon        http://animebytes.tv/favicon.ico
 // @downloadURL https://releases.moe/animebytesmark.user.js
 // @connect     releases.moe
 // @license     MIT
+// @run-at      document-idle
 // ==/UserScript==
 
 /* global $ */
@@ -74,12 +75,13 @@ function torrentsOnPage () {
   const torrentPageTorrents = [...document.querySelectorAll(
     (window.location.href.includes('torrents.php') ? '' : '#anime_table ') + '.group_torrent'
   )].map(elm => {
-    const a = elm.querySelector('a[href*="&torrentid="]')
-    if (!a) return null
+    const links = elm.querySelectorAll('a[href*="&torrentid="]')
+    if (links.length === 0) return null
+    const a = links[links.length - 1]
     return {
       a,
       torrentId: a.href.match(TORRENT_ID_REGEX)[1],
-      separator: a.href.includes('torrents.php') ? ' | ' : ' / '
+      separator: a.href.includes('torrents.php') && links.length === 1 ? ' | ' : ' / '
     }
   }).filter((value) => value)
   const searchResultTorrents = [...document.querySelectorAll(


### PR DESCRIPTION
Changes as proposed in https://github.com/ThaUnknown/releases-moe/pull/17#issuecomment-2294980379

Before
![image](https://github.com/user-attachments/assets/a599f0fc-93b0-42ae-9b57-55f577721f09)
After
![image](https://github.com/user-attachments/assets/831fe2f9-a998-461a-8f86-3cefd28c1d2c)
which matches the way it looks without the Mediainfo Improvements script by placing the tag at the end.

If there are multiple torrent links in one table row (which should only happen because of the Mediainfo Improvements script) I also change the separator from `|` to `/` to match.

Open to suggestions on how to improve this further.