### PR TITLE
ci: disable push on PRs from non collaborators

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -24,6 +24,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to the Container registry
+        # Don't login if the pull request is coming from a different repo (e.g. a fork)
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         uses: docker/login-action@v3
         with:
@@ -43,13 +44,11 @@ jobs:
             type=sha,format=long
             type=raw,value=latest,enable={{is_default_branch}}
 
-      - name: debug
-        run: echo ${{ github.event.pull_request.head.repo.full_name }}
-      
       - name: Build and push Docker images
         uses: docker/build-push-action@v6
         with:
           context: .
+          # Don't push to registry if the pull request is coming from a different repo (e.g. a fork)
           push: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
           provenance: false
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Log in to the Container registry
         # Don't login if the pull request is coming from a different repo (e.g. a fork)
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -49,7 +49,7 @@ jobs:
         with:
           context: .
           # Don't push to registry if the pull request is coming from a different repo (e.g. a fork)
-          push: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+          push: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
           provenance: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -24,6 +24,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to the Container registry
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -41,12 +42,15 @@ jobs:
             type=ref,event=pr
             type=sha,format=long
             type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: debug
+        run: echo ${{ github.event.pull_request.head.repo.full_name }}
       
       - name: Build and push Docker images
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: true
+          push: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
           provenance: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
These fail unconditionally so might as well disable them