### PR TITLE
fix: change how replace is done in embed

### DIFF
--- a/pb/pb_hooks/embeds.js
+++ b/pb/pb_hooks/embeds.js
@@ -45,8 +45,8 @@ module.exports = {
 
     let diff = ''
     for (const part of Diff.diffLines(before, after, { ignoreWhitespace: true })) {
-      if (part.removed) diff += `- ${part.value.trim().replace('\n', '\n- ')}\n`
-      if (part.added) diff += `+ ${part.value.trim().replace('\n', '\n+ ')}\n`
+      if (part.removed) diff += `- ${part.value.trim().replace(/\n/g, '\n- ')}\n`
+      if (part.added) diff += `+ ${part.value.trim().replace(/\n/g, '\n+ ')}\n`
     }
     if (!diff) return ''
     return `\`\`\`diff\n${diff.trim()}\n\`\`\``


### PR DESCRIPTION
The old method would only do one replace per string and node doesn't have replaceAll so a global regex replace will do.