### PR TITLE
fix: example

### DIFF
--- a/sk/src/routes/about/+page.svelte
+++ b/sk/src/routes/about/+page.svelte
@@ -11,7 +11,7 @@
 
   const pocketBaseExample = `import PocketBase from 'pocketbase'
 
-const pb = new PocketBase('${origin}/api/')
+const pb = new PocketBase('${origin}/')
 
 const entriesList = await pb.collection('entries').getList(1, 50, { filter: 'alID=1' })`
 


### PR DESCRIPTION
tested locally

Before:
```console
❯ bun run index.ts
1 | class ClientResponseError extends Error{constructor(e){super("ClientResponseError"),this.url="",this.status=0,this.response={},this.isAbort=!1,this.originalError=null,Object.setPrototypeOf(this,ClientResponseError.prototype),null!==e&&"object"==typeof e&&(this.url="string"==typeof e.url?e.url:"",this.status="number"==typeof e.status?e.status:0,this.isAbort=!!e.isAbort,this.originalError=e.originalError,null!==e.response&&"object"==typeof e.response?this.response=e.response:null!==e.data&&"object"==typeof e.data?this.response=e.data:this.response={}),this.originalError||e instanceof ClientResponseError||(this.originalError=e),"undefined"!=typeof DOMException&&e instanceof DOMException&&(this.isAbort=!0),this.name="ClientResponseError "+this.status,this.message=this.response?.message,this.message||(this.isAbort?this.message="The request was autocancelled. You can find more info in https://github.com/pocketbase/js-sdk#auto-cancellation.":this.originalError?.cause?.message?.includes("ECONNREFUSED ::1")?this.messa | ... truncated

ClientResponseError 404: Not Found.
        url: "https://releases.moe/api/api/collections/entries/records?page=1&perPage=50&filter=alID%3D1",
     status: 404,
   response: {
  code: 404,
  message: "Not Found.",
  data: [Object ...],
},
    isAbort: false,
 originalError: {
  url: "https://releases.moe/api/api/collections/entries/records?page=1&perPage=50&filter=alID%3D1",
  status: 404,
  data: [Object ...],
},

      at new ClientResponseError (C:\Users\raven\Documents\GitHub\delete_me\node_modules\pocketbase\dist\pocketbase.es.mjs:1:56)
      at <anonymous> (C:\Users\raven\Documents\GitHub\delete_me\node_modules\pocketbase\dist\pocketbase.es.mjs:1:37055)

Bun v1.2.2 (Windows x64)
```
After:
```console
❯ bun run index.ts
{
  page: 1,
  perPage: 50,
  totalItems: 1,
  totalPages: 1,
  items: [
    {
      alID: 1,
      collectionId: "3l2x9nxip35gqb5",
      collectionName: "entries",
      comparison: "",
      created: "2023-10-07 18:46:12.601Z",
      id: "frifjcdi90t2zhm",
      incomplete: true,
      notes: "JySzE is ITBD encode + options enjoyings",
      theoreticalBest: "",
      trs: [ "abgwv1bulu891ko", "hdepccs09fbbcxi" ],
      updated: "2024-08-16 14:35:48.043Z",
    }
  ],
}
```