### PR TITLE
fix(ci): build images for PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Log in to the Container registry
         # Don't login if the pull request is coming from a different repo (e.g. a fork)
-        if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == 'ThaUnknown/releases-moe' }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -49,7 +49,7 @@ jobs:
         with:
           context: .
           # Don't push to registry if the pull request is coming from a different repo (e.g. a fork)
-          push: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+          push: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == 'ThaUnknown/releases-moe' }}
           provenance: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     tags:
-      - "*"
+      - 'v[0-9]+.[0-9]+.[0-9]+'
   pull_request:
 
 jobs:
@@ -18,15 +18,17 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
       - name: Log in to the Container registry
         # Don't login if the pull request is coming from a different repo (e.g. a fork)
         if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == 'ThaUnknown/releases-moe' }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -34,7 +36,7 @@ jobs:
     
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -45,7 +47,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker images
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@1dc73863535b631f98b2378be8619f83b136f4a0 # v6.17.0
         with:
           context: .
           # Don't push to registry if the pull request is coming from a different repo (e.g. a fork)


### PR DESCRIPTION
This was always intended but it has been broken. We just didn't find out earlier because there's been very little changes recently. For example, https://github.com/ThaUnknown/releases-moe/pull/64 did not produce a docker image when it should have.

This PR also pins our images by hash and enables dependabot for updating those actions. Actions have been getting hacked left and right so this is just a precaution.