### PR TITLE
FIX: Diff check order.

### DIFF
--- a/pb/pb_hooks/embeds.js
+++ b/pb/pb_hooks/embeds.js
@@ -32,7 +32,7 @@ module.exports = {
     for (const record of trs) {
       if (record?.get(check) === expected) values.add(record?.get(retValue))
     }
-    return [...values].join('\n')
+    return [...values].sort().join('\n')
   },
   wrapMultiple (previous, current, check, retValue, expected = true) {
     const before = this.getValue(previous, check, retValue, expected)


### PR DESCRIPTION
The order has changed due to us changing the order a few months ago leading to cases where the order goes from

`Group1\nGroup2` to `Group2\nGroup1`

This caused the bug with diff checker as the order was different. We are now forcing it to be the same.