### PR TITLE
feat: Update torrent grouping in releasecard

### DIFF
--- a/pb/pb_migrations/1748878262_updated_torrents.js
+++ b/pb/pb_migrations/1748878262_updated_torrents.js
@@ -1,0 +1,29 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate((app) => {
+  const collection = app.findCollectionByNameOrId("oiwizhmushn5qqh")
+
+  // add field
+  collection.fields.addAt(8, new Field({
+    "autogeneratePattern": "",
+    "hidden": false,
+    "id": "text1412308793",
+    "max": 0,
+    "min": 0,
+    "name": "groupUrl",
+    "pattern": "",
+    "presentable": false,
+    "primaryKey": false,
+    "required": false,
+    "system": false,
+    "type": "text"
+  }))
+
+  return app.save(collection)
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("oiwizhmushn5qqh")
+
+  // remove field
+  collection.fields.removeById("text1412308793")
+
+  return app.save(collection)
+})

--- a/sk/src/lib/components/ReleaseCard.svelte
+++ b/sk/src/lib/components/ReleaseCard.svelte
@@ -4,6 +4,7 @@
   import * as Card from '$lib/components/ui/card'
   import { Button } from '$lib/components/ui/button'
   import { PRIVATE_TRACKERS } from '$lib/torrent'
+  import * as DropdownMenu from '$lib/components/ui/dropdown-menu'
 
   export let torrents: TorrentsResponse[]
   export let releaseGroup: string
@@ -19,6 +20,22 @@
       if (size && !sizes.includes(size)) sizes.push(size)
     }
     return { isBest, isDual, sizes }
+  }
+
+  function mapToTracker(torrents: TorrentsResponse[]) {
+    const map: Map<string, TorrentsResponse> = new Map();
+
+    for (const torrent of torrents) {
+      const keyValue = torrent.tracker;
+
+      if (!map.has(keyValue)) {
+        map.set(keyValue, []);
+      }
+
+      map.get(keyValue).push(torrent);
+    }
+
+    return map;
   }
 
   const icons: Record<TorrentsTrackerOptions, string> = {
@@ -40,6 +57,8 @@
   const alias: Partial<Record<TorrentsTrackerOptions, string>> = {
     AB: 'Private Tracker'
   }
+
+  let groupedTorrents = mapToTracker(torrents)
 </script>
 
 {#if torrents}
@@ -65,14 +84,34 @@
     </Card.Content>
     <Card.Footer>
       <div class='grid grid-cols-2 gap-4 w-full'>
-        {#each torrents as torrent}
-          {@const isPrivate = PRIVATE_TRACKERS.includes(torrent.tracker)}
-          <Button size='sm' variant='outline' class='px-4 {isPrivate && 'pt-button pointer-events-none'}' href={torrent.url} data-href={torrent.url} target='_blank'>
-            {#if icons[torrent.tracker]}
-              <img src={icons[torrent.tracker]} alt={torrent.tracker} class='w-3 h-3 me-2' />
-            {/if}
-            {alias[torrent.tracker] || torrent.tracker}
-          </Button>
+        {#each groupedTorrents.entries() as [tracker, torrents]}
+          {@const isPrivate = PRIVATE_TRACKERS.includes(tracker)}
+          {#if torrents.length == 1 || torrents[0].groupUrl}
+            {@const torrent = torrents[0]}
+            <Button size='sm' variant='outline' class='px-4 {isPrivate && 'pt-button pointer-events-none'}' href={torrent.groupUrl || torrent.url} data-href={torrent.groupUrl || torrent.url} target='_blank'>
+              {#if icons[torrent.tracker]}
+                <img src={icons[torrent.tracker]} alt={torrent.tracker} class='w-3 h-3 me-2' />
+              {/if}
+              {alias[torrent.tracker] || torrent.tracker}
+            </Button>
+          {:else}          
+            <DropdownMenu.Root>
+              <DropdownMenu.Trigger asChild let:builder>
+                <Button variant='outline' size='sm' class='px-4 {isPrivate && 'pt-button'}' builders={[builder]}>
+                  <img src={icons[tracker]} alt={tracker} class='w-3 h-3 me-2' />
+                  {alias[tracker] || tracker}
+                </Button>
+              </DropdownMenu.Trigger>
+              <DropdownMenu.Content>
+                {#each torrents as torrent, index}                
+                  <DropdownMenu.Item class='cursor-pointer {isPrivate && 'pt-button pointer-events-none'}' href={torrent.url} data-href={torrent.url} target='_blank'>
+                    <img src={icons[tracker]} alt={tracker} class='w-3 h-3 me-2' /> 
+                    Torrent #{index+1}
+                  </DropdownMenu.Item> 
+                {/each}
+              </DropdownMenu.Content>
+            </DropdownMenu.Root>
+          {/if}
         {/each}
       </div>
     </Card.Footer>

--- a/sk/src/lib/components/TorrentEditorForm.svelte
+++ b/sk/src/lib/components/TorrentEditorForm.svelte
@@ -53,7 +53,7 @@
     </div>
   </div>
 </div>
-<div class='grid grid-cols-2 gap-3'>
+<div class='grid grid-cols-3 gap-3'>
   <div>
     <div class='mb-2'>
       <Label>Tracker</Label>
@@ -73,6 +73,12 @@
     <div class='mb-2'>
       <Label for={'url' + i}>URL</Label>
       <Input type='text' class='form-control' on:change={updateTracker} required id={'url' + i} bind:value={torrent.url} />
+    </div>
+  </div>
+  <div>
+    <div class='mb-2'>
+      <Label for={'groupUrl' + i}>Group URL</Label>
+      <Input type='text' class='form-control' id={'groupUrl' + i} bind:value={torrent.groupUrl} />
     </div>
   </div>
 </div>

--- a/sk/src/lib/pocketbase/generated-types.ts
+++ b/sk/src/lib/pocketbase/generated-types.ts
@@ -118,6 +118,7 @@ export type TorrentsRecord<Tfiles = { length: number, name: string }[]> = {
 	releaseGroup: string
 	tracker: TorrentsTrackerOptions
 	url: string
+	groupUrl?: string
 }
 
 export type UsersRecord = {

--- a/sk/static/animebytesmark.user.js
+++ b/sk/static/animebytesmark.user.js
@@ -4,7 +4,7 @@
 // @namespace   ThaUnknown
 // @match       *://animebytes.tv/*
 // @match       *://releases.moe/*
-// @version     1.5.0
+// @version     1.6.0
 // @author      ThaUnknown & Jimbo
 // @grant       GM_xmlhttpRequest
 // @icon        http://animebytes.tv/favicon.ico
@@ -188,6 +188,15 @@ function revealABEntries () {
     elm.href = new URL(elm.dataset.href, 'https://animebytes.tv')
     elm.classList.remove('pointer-events-none')
     elm.removeAttribute('data-href')
+    elm.childNodes[0].src = '/ab.ico'
+    if (elm.childNodes[2].textContent.includes('Private')) {
+      elm.childNodes[2].textContent = 'AnimeBytes'
+    }
+    return true
+  }, false, 50)
+
+  waitForKeyElements('button.pt-button', (elm) => {
+    elm.href = new URL(elm.dataset.href, 'https://animebytes.tv')
     elm.childNodes[0].src = '/ab.ico'
     elm.childNodes[2].textContent = 'AnimeBytes'
     return true


### PR DESCRIPTION
It will now only ever display one button per tracker. Said button will now support dropdown in cases without a groupUrl. If it contains a groupUrl it will only direct it to that page.