### PR TITLE
feat: publish two seperate dev and stable images

### DIFF
--- a/.github/workflows/docker-dev.yaml
+++ b/.github/workflows/docker-dev.yaml
@@ -1,0 +1,56 @@
+name: Build and Push Docker Image (Dev)
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Log in to the Container registry
+        # Don't login if the pull request is coming from a different repo (e.g. a fork)
+        if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == 'ThaUnknown/releases-moe' }}
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+    
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha,format=long
+            type=raw,value=dev
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          # Don't push to registry if the pull request is coming from a different repo (e.g. a fork)
+          push: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == 'ThaUnknown/releases-moe' }}
+          provenance: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-latest.yaml
+++ b/.github/workflows/docker-latest.yaml
@@ -1,12 +1,6 @@
-name: Build and Push Docker Image
+name: Build and Push Docker Image (Latest)
 
-on:
-  push:
-    branches:
-      - main
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
-  pull_request:
+on: [workflow_dispatch]
 
 jobs:
   build-and-push:
@@ -26,8 +20,6 @@ jobs:
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Log in to the Container registry
-        # Don't login if the pull request is coming from a different repo (e.g. a fork)
-        if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == 'ThaUnknown/releases-moe' }}
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
           registry: ghcr.io
@@ -40,18 +32,13 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=ref,event=tag
-            type=ref,event=branch
-            type=ref,event=pr
             type=sha,format=long
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest
 
       - name: Build and push Docker images
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .
-          # Don't push to registry if the pull request is coming from a different repo (e.g. a fork)
-          push: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == 'ThaUnknown/releases-moe' }}
           provenance: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ This repository holds the source code that powers [SeaDex](https://releases.moe/
 # Deployment
 To deploy SeaDex, you need [docker](https://docs.docker.com/). SeaDex images are available on [ghcr.io](https://github.com/ThaUnknown/releases-moe/pkgs/container/releases-moe).
 
+## Image Tags
+
+- `latest` - Stable release version
+- `dev` - Development version, follows the main branch
+
 ```yaml
 ---
 services:


### PR DESCRIPTION
The goal here is to allow auto-updates:
- The deployment machine will track the `latest` tag. Images with the `latest` tag are not built automatically, they must be triggered by hand via `workflow_dispatch`.
- The testing machine will track the `dev` tag. Images with the `dev` tag are built automatically for every commit to main.