### PR TITLE
ci: add a cooldown on updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,9 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    cooldown:
+      default-days: 14
     groups:
       actions:
         patterns:


### PR DESCRIPTION
Pulling updates day 1 seems to be a bad idea